### PR TITLE
fix: build error

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -1,7 +1,7 @@
 def gem_config(conf)
   conf.gembox 'full-core'
 
-  conf.gem :github => 'Asmod4n/mruby-uri-parser'
+  conf.gem :github => 'Asmod4n/mruby-uri-parser', :checksum_hash => "96e15ac2a49b1dda2800c07509be7aad3c859e48"
   conf.gem :github => 'iij/mruby-io'
   conf.gem :github => 'iij/mruby-env'
   conf.gem :github => 'iij/mruby-dir'
@@ -9,9 +9,9 @@ def gem_config(conf)
   conf.gem :github => 'iij/mruby-process'
   conf.gem :github => 'iij/mruby-pack'
   conf.gem :github => 'iij/mruby-socket'
-  conf.gem :github => 'mattn/mruby-json'
+  conf.gem :github => 'mattn/mruby-json', :checksum_hash => "a3414856b3105bc6a68d8472f204d52931a7fd7d"
   conf.gem :github => 'mattn/mruby-onig-regexp'
-  conf.gem :github => 'matsumoto-r/mruby-redis'
+  conf.gem :github => 'matsumoto-r/mruby-redis', :checksum_hash => "af40e42492c1a24ec88a15cd56eee9edc7e69788"
   # conf.gem :github => 'matsumoto-r/mruby-memcached'
   conf.gem :github => 'matsumoto-r/mruby-sleep'
   conf.gem :github => 'matsumoto-r/mruby-userdata'


### PR DESCRIPTION
Currently nmrb (f3fce84cc67e7bcaeb50c0af84ab18ecd75ac6a0) uses mruby-1.2.0, but some mgems follows new version of mruby. This pull-request sets commit id to them for building.

### Before pull-request

```
$ docker-compose run compile
...
CC    build/mrbgems/mruby-uri-parser/src/mrb_uri_parser.c -> build/host/mrbgems/mruby-uri-parser/src/mrb_uri_parser.o
/home/mruby/code/mruby/build/mrbgems/mruby-uri-parser/src/mrb_uri_parser.c:127:27: error: 
      implicit declaration of function 'mrb_num_mul' is invalid in C99
      [-Werror,-Wimplicit-function-declaration]
  mrb_value encoded_len = mrb_num_mul(mrb, mrb_fixnum_value(RSTRING_LEN(...
                          ^
/home/mruby/code/mruby/build/mrbgems/mruby-uri-parser/src/mrb_uri_parser.c:127:13: error: 
      initializing 'mrb_value' (aka 'struct mrb_value') with an expression of
      incompatible type 'int'
  ...encoded_len = mrb_num_mul(mrb, mrb_fixnum_value(RSTRING_LEN(url_str)), mrb_fixnum_value(3));
     ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
/home/mruby/code/mruby/build/mrbgems/mruby-uri-parser/src/mrb_uri_parser.c:127:27: error: 
      implicit declaration of function 'mrb_num_mul' is invalid in C99
      [-Werror,-Wimplicit-function-declaration]
  mrb_value encoded_len = mrb_num_mul(mrb, mrb_fixnum_value(RSTRING_LEN(...
                          ^
/home/mruby/code/mruby/build/mrbgems/mruby-uri-parser/src/mrb_uri_parser.c:127:13: error: 
      initializing 'mrb_value' (aka 'struct mrb_value') with an expression of
      incompatible type 'int'
  ...encoded_len = mrb_num_mul(mrb, mrb_fixnum_value(RSTRING_LEN(url_str)), mrb_fixnum_value(3));
     ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
rake aborted!
Command failed with status (1): [clang -g -std=gnu99 -O3 -Wall -Werror-impl...]
/home/mruby/code/mruby/tasks/mruby_build_commands.rake:31:in `_run'
/home/mruby/code/mruby/tasks/mruby_build_commands.rake:36:in `rescue in _run'
/home/mruby/code/mruby/tasks/mruby_build_commands.rake:32:in `_run'
/home/mruby/code/mruby/tasks/mruby_build_commands.rake:88:in `run'
/home/mruby/code/mruby/tasks/mruby_build_commands.rake:112:in `block (2 levels) in define_rules'
Command failed with status (1): ["clang" -g -std=gnu99 -O3 -Wall -Werror-im...]
/home/mruby/code/mruby/tasks/mruby_build_commands.rake:33:in `_run'
/home/mruby/code/mruby/tasks/mruby_build_commands.rake:88:in `run'
/home/mruby/code/mruby/tasks/mruby_build_commands.rake:112:in `block (2 levels) in define_rules'
Tasks: TOP => compile => all => /home/mruby/code/mruby/build/host/lib/libmruby.flags.mak => /home/mruby/code/mruby/build/host/lib/libmruby.a => /home/mruby/code/mruby/build/host/mrbgems/mruby-uri-parser/src/mrb_uri_parser.o
(See full trace by running task with --trace)
```

### After pull-request

```
$ docker-compose run compile
...
CC    mrbgems/mruby-bin-strip/tools/mruby-strip/mruby-strip.c -> build/host/mrbgems/mruby-bin-strip/tools/mruby-strip/mruby-strip.o
LD    build/host/bin/mruby-strip
CC    mrbgems/mruby-bin-mruby/tools/mruby/mruby.c -> build/host/mrbgems/mruby-bin-mruby/tools/mruby/mruby.o
LD    build/host/bin/mruby
CC    mrbgems/mruby-bin-mirb/tools/mirb/mirb.c -> build/host/mrbgems/mruby-bin-mirb/tools/mirb/mirb.o
LD    build/host/bin/mirb
CC    ../tools/nmrb/nmrb.c -> build/host/mrbgems/nmrb/tools/nmrb/nmrb.o
LD    build/host/bin/nmrb

Build summary:

================================================
      Config Name: host
 Output Directory: build/host
         Binaries: mruby-config, mrbc, mrbtest
    Included Gems:
             mruby-sprintf - standard Kernel#sprintf method
             mruby-print - standard print/puts/p
             mruby-fiber - Fiber class
             mruby-enum-ext - Enumerable module extension
             mruby-enumerator - Enumerator class
             mruby-compiler - mruby compiler library
             mruby-bin-mrbc - mruby compiler executable
             mruby-range-ext - Range class extension
             mruby-error - extensional error handling
             mruby-bin-strip - irep dump debug section remover command
               - Binaries: mruby-strip
             mruby-string-ext - String class extension
             mruby-kernel-ext - Kernel module extension
             mruby-toplevel-ext - toplevel object (main) methods extension
             mruby-proc-ext - Proc class extension
             mruby-exit - Kernel#exit method
             mruby-bin-mruby - mruby command
               - Binaries: mruby
             mruby-struct - standard Struct class
             mruby-bin-mirb - mirb command
               - Binaries: mirb
             mruby-enum-lazy - Enumerable::Lazy class
             mruby-array-ext - Array class extension
             mruby-symbol-ext - Symbol class extension
             mruby-objectspace - ObjectSpace class
             mruby-hash-ext - Hash class extension
             mruby-eval - standard Kernel#eval method
             mruby-time - standard Time class
             mruby-object-ext - Object class extension
             mruby-math - standard Math module
             mruby-random - Random class
             mruby-numeric-ext - Numeric class extension
             mruby-errno
             mruby-uri-parser - URI parser for mruby
             mruby-io
             mruby-env
             mruby-dir
             mruby-digest
             mruby-process
             mruby-pack
             mruby-socket
             mruby-json
             mruby-onig-regexp
             mruby-sleep - 0.0.1
             mruby-pointer - 0.0.1 - Provide mruby C API which shared pointer between two mrb_states
             mruby-redis - 0.0.1
             mruby-userdata
             mruby-uname - 0.0.1 - system uname binding
             mruby-mutex
             mruby-cache
             mruby-hogun - This is a convenient library to build the command line interface. 
             mruby-mtest
             nmrb - nmrb
               - Binaries: nmrb
             mruby-test - mruby test
================================================

$ echo $?
0
```
